### PR TITLE
feat: add reset method

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ class TimeoutController extends AbortController {
    */
   constructor (ms) {
     super()
+    this._ms = ms
     this._timer = retimer(() => this.abort(), ms)
   }
 
@@ -24,6 +25,14 @@ class TimeoutController extends AbortController {
    */
   clear () {
     this._timer.clear()
+  }
+
+  /**
+   * Resets the timer
+   */
+  reset () {
+    this._timer.clear()
+    this._timer = retimer(() => this.abort(), this._ms)
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -40,3 +40,16 @@ test('can clear the timeout', async t => {
 
   t.is(timeoutController.signal.aborted, false)
 })
+
+test('can reset the timeout', async t => {
+  const timeoutController = new TimeoutController(50)
+
+  await delay(30)
+  timeoutController.reset() // now expires at 80
+
+  await delay(30)
+  t.is(timeoutController.signal.aborted, false) // should not have expired at 60
+
+  await delay(30)
+  t.is(timeoutController.signal.aborted, true) // should have now expired at 90
+})


### PR DESCRIPTION
Allows us to implement rolling window timeouts. i.e. timeout 10s after last received byte, not after 10s and still recieving data.