### PR TITLE
Change import such that TS can infer type

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const AbortController = require('abort-controller')
+const { AbortController } = require('abort-controller')
 const retimer = require('retimer')
 
 class TimeoutController extends AbortController {


### PR DESCRIPTION
When this is used from the typescript most things can be inferred, except for `AbortController` which has it types defined as ES module (see https://github.com/mysticatea/abort-controller/blob/master/dist/abort-controller.d.ts)

TS does not interpret `default export` as `module.exports` which leads to problems downstream. This change just uses named import that is also provided `abort-controller` which resolves all the issues.